### PR TITLE
feat(preview): Ctrl+wheel zoom in Marco, full preview zoom ported to Polo

### DIFF
--- a/changelog/marco.md
+++ b/changelog/marco.md
@@ -9,6 +9,9 @@ Version scheme note: versions are reconstructed as `0.YY.ZZ` from git history us
 
 ## [Unreleased]
 
+### Added
+- **Ctrl+scroll wheel** now also zooms the preview, alongside the existing `Ctrl+=`/`Ctrl+-`/`Ctrl+0` shortcuts and the in-page zoom toolbar's `+`/`−`/reset buttons. One wheel notch = one zoom step, routed through the same `marco_zoom:in|out` IPC path the toolbar buttons already use. _(2026-08-25)_
+
 ## [0.25.0] - 2026-08-20
 
 _Covers the `unified-webviewer` branch: commits 31a6aac (2026-07-14) through 2d34df7 (2026-08-18), plus the fixes dated 2026-08-20 below._

--- a/changelog/polo.md
+++ b/changelog/polo.md
@@ -9,6 +9,9 @@ Version scheme note: versions are reconstructed as `0.YY.ZZ` from git history us
 
 ## [Unreleased]
 
+### Added
+- **Preview zoom**, ported over from Marco's editor: an in-page toolbar (`+`/`−`/reset, bottom-right corner of the preview, revealed on hover), `Ctrl+=`/`Ctrl+-`/`Ctrl+0` keyboard shortcuts, and `Ctrl+scroll wheel`. Deliberately session-only — the zoom level is not written to settings, since Polo opens a different document on every launch rather than one long-lived editing session. _(2026-08-25)_
+
 ## [0.25.0] - 2026-08-20
 
 _Covers the `unified-webviewer` branch: commits 31a6aac (2026-07-14) through 2d34df7 (2026-08-18), plus the fixes dated 2026-08-20 below._

--- a/documentation/user_guide/user_guide.md
+++ b/documentation/user_guide/user_guide.md
@@ -527,6 +527,14 @@ Apply different styling to your preview:
 - Themes affect how your Markdown renders in preview mode
 - Automatic theme integration with light/dark mode detection
 
+### Preview Zoom
+Zoom the rendered preview independently of your editor font size:
+- **Keyboard**: `Ctrl+=`/`Ctrl+-` to zoom in/out, `Ctrl+0` to reset
+- **Mouse**: `Ctrl+scroll wheel` over the preview
+- **On-screen controls**: hover over the preview to reveal a small +/−/reset toolbar in its bottom-right corner, showing the current zoom percentage
+- Zoom range is 50%–300%, in 10% steps
+- Polo (the standalone viewer) has the same controls, except there the zoom level resets to 100% on every restart rather than being remembered
+
 ## Settings & Preferences
 
 Access preferences through **View → Preferences** (`Ctrl+,`).
@@ -589,6 +597,11 @@ The settings dialog is organized into tabs. Labels and tooltips update live when
 
 ### Headings
 - `Ctrl+1` through `Ctrl+6` - Insert heading levels
+
+### Preview
+- `Ctrl+=` / `Ctrl+-` - Zoom preview in/out
+- `Ctrl+0` - Reset preview zoom
+- `Ctrl+scroll wheel` (over the preview) - Zoom preview in/out
 
 ### Help
 - `Ctrl+?` - Show keyboard shortcuts

--- a/marco/src/components/viewer/javascript.rs
+++ b/marco/src/components/viewer/javascript.rs
@@ -50,6 +50,16 @@ pub fn wheel_js(scale: f64) -> String {
         }}
 
         window.addEventListener('wheel', function(e){{
+            if (e.ctrlKey) {{
+                e.preventDefault();
+                try {{
+                    if (window.ipc && typeof window.ipc.postMessage === 'function') {{
+                        window.ipc.postMessage('marco_zoom:' + (e.deltaY < 0 ? 'in' : 'out'));
+                    }}
+                }} catch (_) {{}}
+                return;
+            }}
+
             if (Math.abs(e.deltaY) < 0.0001 && Math.abs(e.deltaX) < 0.0001) return;
 
             const sc = findScroll(e.target);

--- a/polo/src/components/menu.rs
+++ b/polo/src/components/menu.rs
@@ -374,6 +374,9 @@ fn menu_btn(text: &str) -> Button {
 //   win.polo-clear-recent     — clears the recent files list
 //   win.polo-reload           — re-reads the current file from disk (F5)
 //   win.polo-find             — reveals/focuses the toolbar find-in-page bar (Ctrl+F)
+//   win.polo-zoom-in          — increases preview zoom (Ctrl+=/Ctrl+Plus)
+//   win.polo-zoom-out         — decreases preview zoom (Ctrl+-)
+//   win.polo-zoom-reset       — resets preview zoom to 100% (Ctrl+0)
 //   win.polo-quit             — closes the window
 
 #[allow(clippy::too_many_arguments)]
@@ -613,6 +616,51 @@ fn build_file_popover(
         // Register Ctrl+F accelerator
         if let Some(app) = window.application() {
             app.set_accels_for_action("win.polo-find", &["<Control>f"]);
+        }
+    }
+
+    // Preview zoom shortcuts — same in/out/reset delta logic the in-page zoom
+    // toolbar's buttons and Ctrl+wheel drive via `polo_zoom:` IPC (see
+    // `viewer::zoom::step`, `viewer::zoom_bar`). Session-only, not persisted.
+    if window.lookup_action("polo-zoom-in").is_none() {
+        let zoom_in_action = gio::SimpleAction::new("polo-zoom-in", None);
+        let wv = webview.clone();
+        zoom_in_action.connect_activate(move |_, _| {
+            crate::components::viewer::zoom::step("in", &wv);
+        });
+        window.add_action(&zoom_in_action);
+        if let Some(app) = window.application() {
+            app.set_accels_for_action(
+                "win.polo-zoom-in",
+                &["<Control>plus", "<Control>equal", "<Control>KP_Add"],
+            );
+        }
+    }
+
+    if window.lookup_action("polo-zoom-out").is_none() {
+        let zoom_out_action = gio::SimpleAction::new("polo-zoom-out", None);
+        let wv = webview.clone();
+        zoom_out_action.connect_activate(move |_, _| {
+            crate::components::viewer::zoom::step("out", &wv);
+        });
+        window.add_action(&zoom_out_action);
+        if let Some(app) = window.application() {
+            app.set_accels_for_action(
+                "win.polo-zoom-out",
+                &["<Control>minus", "<Control>KP_Subtract"],
+            );
+        }
+    }
+
+    if window.lookup_action("polo-zoom-reset").is_none() {
+        let zoom_reset_action = gio::SimpleAction::new("polo-zoom-reset", None);
+        let wv = webview.clone();
+        zoom_reset_action.connect_activate(move |_, _| {
+            crate::components::viewer::zoom::step("reset", &wv);
+        });
+        window.add_action(&zoom_reset_action);
+        if let Some(app) = window.application() {
+            app.set_accels_for_action("win.polo-zoom-reset", &["<Control>0", "<Control>KP_0"]);
         }
     }
 

--- a/polo/src/components/viewer/mod.rs
+++ b/polo/src/components/viewer/mod.rs
@@ -44,6 +44,8 @@ pub mod link_hover;
 pub mod loading_overlay;
 pub mod platform_webview;
 pub mod rendering;
+pub mod zoom;
+pub mod zoom_bar;
 
 pub use empty_state::show_empty_state_with_theme;
 pub use rendering::load_and_render_markdown;

--- a/polo/src/components/viewer/platform_webview.rs
+++ b/polo/src/components/viewer/platform_webview.rs
@@ -47,6 +47,10 @@ type FindReportCallbackCell = std::rc::Rc<
         Option<std::rc::Rc<dyn Fn(crate::components::viewer::find_engine::FindReport)>>,
     >,
 >;
+/// Listener for the in-page zoom toolbar's `polo_zoom:in|out|reset` IPC
+/// messages (see [`crate::components::viewer::zoom_bar`]), also used by
+/// Ctrl+wheel (posted from the same in-page script).
+type ZoomActionCallbackCell = std::rc::Rc<std::cell::RefCell<Option<std::rc::Rc<dyn Fn(&str)>>>>;
 
 /// Unified WebView wrapper exposed to the rest of the codebase.
 #[derive(Clone)]
@@ -76,6 +80,10 @@ pub struct PlatformWebView {
     /// Listener for `polo_find:count=N,index=K` IPC messages emitted by the
     /// `PoloFind` JS engine. See [`Self::set_find_report_callback`].
     find_report_callback: FindReportCallbackCell,
+    /// Listener for `polo_zoom:in|out|reset` IPC messages emitted by the
+    /// in-page zoom toolbar (buttons and Ctrl+wheel). See
+    /// [`Self::set_zoom_action_handler`].
+    zoom_action_callback: ZoomActionCallbackCell,
     /// When `true` the tick callback keeps the wry HWND at −32000,−32000 so
     /// the GTK loading-overlay frame is visible above it (Windows-only effect;
     /// on Linux the overlay stacks above the webview widget natively).
@@ -115,6 +123,8 @@ impl PlatformWebView {
         let open_file_click_callback: OpenFileClickCallbackCell =
             std::rc::Rc::new(std::cell::RefCell::new(None));
         let find_report_callback: FindReportCallbackCell =
+            std::rc::Rc::new(std::cell::RefCell::new(None));
+        let zoom_action_callback: ZoomActionCallbackCell =
             std::rc::Rc::new(std::cell::RefCell::new(None));
         let is_offscreen_for_loading = std::rc::Rc::new(std::cell::Cell::new(false));
 
@@ -257,6 +267,7 @@ impl PlatformWebView {
             drag_hover_callback,
             open_file_click_callback,
             find_report_callback,
+            zoom_action_callback,
             is_offscreen_for_loading,
             load_version: std::rc::Rc::new(std::cell::Cell::new(0u64)),
             bg_css_provider,
@@ -301,13 +312,9 @@ impl PlatformWebView {
             .with_ipc_handler({
                 let open_file_cb = self.open_file_click_callback.clone();
                 let find_cb = self.find_report_callback.clone();
+                let zoom_cb = self.zoom_action_callback.clone();
                 move |req: wry::http::Request<String>| {
-                    let msg = req.body().as_str();
-                    if msg == "polo_open_file:" {
-                        handle_open_file_click_ipc(&open_file_cb);
-                    } else if let Some(payload) = msg.strip_prefix("polo_find:") {
-                        handle_find_report_ipc(payload, &find_cb);
-                    }
+                    dispatch_polo_ipc(req.body().as_str(), &open_file_cb, &find_cb, &zoom_cb);
                 }
             })
             .with_drag_drop_handler(make_drag_drop_handler(
@@ -505,13 +512,9 @@ impl PlatformWebView {
                 .with_ipc_handler({
                     let open_file_cb = self.open_file_click_callback.clone();
                     let find_cb = self.find_report_callback.clone();
+                    let zoom_cb = self.zoom_action_callback.clone();
                     move |req: wry::http::Request<String>| {
-                        let msg = req.body().as_str();
-                        if msg == "polo_open_file:" {
-                            handle_open_file_click_ipc(&open_file_cb);
-                        } else if let Some(payload) = msg.strip_prefix("polo_find:") {
-                            handle_find_report_ipc(payload, &find_cb);
-                        }
+                        dispatch_polo_ipc(req.body().as_str(), &open_file_cb, &find_cb, &zoom_cb);
                     }
                 })
                 .with_drag_drop_handler(make_drag_drop_handler(
@@ -581,6 +584,14 @@ impl PlatformWebView {
         F: Fn(crate::components::viewer::find_engine::FindReport) + 'static,
     {
         *self.find_report_callback.borrow_mut() = Some(std::rc::Rc::new(callback));
+    }
+
+    /// Install a callback invoked when the in-page zoom toolbar posts a
+    /// `polo_zoom:in|out|reset` IPC message (button click or Ctrl+wheel — see
+    /// [`crate::components::viewer::zoom_bar`]). The callback receives the
+    /// bare action string (`"in"`, `"out"`, or `"reset"`).
+    pub fn set_zoom_action_handler<F: Fn(&str) + 'static>(&self, callback: F) {
+        *self.zoom_action_callback.borrow_mut() = Some(std::rc::Rc::new(callback));
     }
 
     /// Move the wry HWND off-screen (`offscreen = true`) so the GTK loading-
@@ -1027,6 +1038,25 @@ fn make_drag_drop_handler(
     }
 }
 
+/// Shared IPC-message branching for both platforms' `.with_ipc_handler`
+/// builder sites (`build_webview_gtk` on Linux, the first-build path in
+/// `load_html_with_base` on Windows) — factored out here rather than left
+/// duplicated inline in each closure, since both need identical branches.
+fn dispatch_polo_ipc(
+    msg: &str,
+    open_file_cb: &OpenFileClickCallbackCell,
+    find_cb: &FindReportCallbackCell,
+    zoom_cb: &ZoomActionCallbackCell,
+) {
+    if msg == "polo_open_file:" {
+        handle_open_file_click_ipc(open_file_cb);
+    } else if let Some(payload) = msg.strip_prefix("polo_find:") {
+        handle_find_report_ipc(payload, find_cb);
+    } else if let Some(action) = msg.strip_prefix("polo_zoom:") {
+        handle_zoom_action_ipc(action, zoom_cb);
+    }
+}
+
 /// Dispatch a `polo_open_file:` IPC message (the empty-state's "Open File"
 /// button) to the installed [`PlatformWebView::set_open_file_click_handler`]
 /// callback on the GTK main context — `with_ipc_handler` closures run on
@@ -1052,6 +1082,18 @@ fn handle_find_report_ipc(payload: &str, find_cb: &FindReportCallbackCell) {
     let cb_opt = find_cb.borrow().clone();
     if let Some(cb) = cb_opt {
         gtk4::glib::MainContext::default().invoke_local(move || cb(report));
+    }
+}
+
+/// Dispatch a `polo_zoom:` IPC payload (posted by the in-page zoom toolbar's
+/// buttons and its Ctrl+wheel listener — see `viewer::zoom_bar`) to the
+/// installed [`PlatformWebView::set_zoom_action_handler`] callback, same
+/// `invoke_local` marshalling as [`handle_open_file_click_ipc`].
+fn handle_zoom_action_ipc(action: &str, zoom_cb: &ZoomActionCallbackCell) {
+    let cb_opt = zoom_cb.borrow().clone();
+    if let Some(cb) = cb_opt {
+        let action = action.to_string();
+        gtk4::glib::MainContext::default().invoke_local(move || cb(&action));
     }
 }
 

--- a/polo/src/components/viewer/rendering.rs
+++ b/polo/src/components/viewer/rendering.rs
@@ -195,6 +195,9 @@ fn build_html_from_content(
             // why this replaced a native GTK Popover.
             combined_css.push_str("\n\n/* Link-hover tooltip */\n");
             combined_css.push_str(crate::components::viewer::link_hover::CSS);
+            // In-page zoom toolbar CSS — see `viewer::zoom_bar`.
+            combined_css.push_str("\n\n/* Zoom toolbar */\n");
+            combined_css.push_str(crate::components::viewer::zoom_bar::CSS);
 
             // Append the link-hover tooltip markup (see `viewer::link_hover`)
             // and the shared drag-and-drop overlay markup (see
@@ -205,11 +208,12 @@ fn build_html_from_content(
             // reason it already runs after `html` so every link in the
             // document exists first.
             let html_with_js = format!(
-                "{}{}{}{}",
+                "{}{}{}{}{}",
                 html,
                 crate::components::viewer::link_hover::html(),
                 crate::components::viewer::drop_overlay::html(),
-                crate::components::viewer::javascript::HOVER_REPORT_JS
+                crate::components::viewer::javascript::HOVER_REPORT_JS,
+                crate::components::viewer::zoom_bar::html()
             );
 
             let theme_class = format!("theme-{}", theme_mode);

--- a/polo/src/components/viewer/zoom.rs
+++ b/polo/src/components/viewer/zoom.rs
@@ -1,0 +1,92 @@
+//! Preview zoom state for Polo's viewer.
+//!
+//! Deliberately session-only: the zoom level lives in a thread-local for the
+//! lifetime of the running process and is never written to `settings.ron`.
+//! Polo opens a different document on every launch (unlike Marco's long-lived
+//! editing session), so a zoom level that survived a restart would carry over
+//! from whatever was last read into an unrelated document. If that turns out
+//! to be wanted after all, persistence can be added later as its own step —
+//! see the shared `preview_zoom` field already on
+//! `marco_shared::logic::swanson::LayoutSettings`, which Marco uses.
+//!
+//! Mirrors `marco/src/components/editor/editor_manager.rs`'s zoom state, but
+//! without a "registered primary webview" thread-local registry — Polo has
+//! exactly one `PlatformWebView` per process and every call site already has
+//! a reference to it, so it's passed in directly instead.
+
+use super::platform_webview::PlatformWebView;
+use std::cell::Cell;
+
+/// Zoom step increment/decrement per action (button click, keyboard shortcut,
+/// or Ctrl+wheel notch).
+pub const ZOOM_STEP: f64 = 0.1;
+/// Minimum allowed zoom level.
+pub const ZOOM_MIN: f64 = 0.5;
+/// Maximum allowed zoom level.
+pub const ZOOM_MAX: f64 = 3.0;
+/// Default zoom level.
+pub const ZOOM_DEFAULT: f64 = 1.0;
+
+thread_local! {
+    static PREVIEW_ZOOM: Cell<f64> = const { Cell::new(ZOOM_DEFAULT) };
+}
+
+/// Get the current in-session preview zoom level.
+pub fn get_preview_zoom() -> f64 {
+    PREVIEW_ZOOM.with(|c| c.get())
+}
+
+/// Set the current preview zoom level (clamped to `ZOOM_MIN..=ZOOM_MAX`) and
+/// apply it to `webview` immediately.
+pub fn set_preview_zoom(zoom: f64, webview: &PlatformWebView) {
+    let clamped = zoom.clamp(ZOOM_MIN, ZOOM_MAX);
+    PREVIEW_ZOOM.with(|c| c.set(clamped));
+
+    // `__poloApplyZoom` (defined in `zoom_bar::html`) scales `<body>`,
+    // relocates the zoom bar so it isn't scaled along with the content, and
+    // updates the percent label. Fall back to setting `style.zoom` directly
+    // in case the bar's script hasn't initialized yet.
+    let pct = (clamped * 100.0).round() as i32;
+    let js = format!(
+        "if (typeof window.__poloApplyZoom === 'function') {{ \
+             window.__poloApplyZoom({zoom}); \
+         }} else {{ \
+             document.body.style.zoom = '{zoom}'; \
+             if (typeof window.__poloSetZoomLabel === 'function') {{ \
+                 window.__poloSetZoomLabel({pct}); \
+             }} \
+         }}",
+        zoom = clamped,
+        pct = pct,
+    );
+    webview.evaluate_script(&js);
+}
+
+/// Re-apply the current in-session zoom level to `webview`.
+///
+/// Call this after every document load: `document.body.style.zoom` lives in
+/// the DOM of the currently-loaded page, so it resets on every navigation.
+/// Unlike Marco (where most preview refreshes are incremental DOM patches
+/// that never touch `style.zoom`), every render in Polo is a full navigation
+/// — opening a file, F5 reload, a theme switch, or following a local link —
+/// so this needs to run unconditionally on every `load-finished` signal.
+pub fn reapply(webview: &PlatformWebView) {
+    set_preview_zoom(get_preview_zoom(), webview);
+}
+
+/// Apply one zoom step: `"in"` (+`ZOOM_STEP`), `"out"` (-`ZOOM_STEP`), or
+/// `"reset"` (back to `ZOOM_DEFAULT`). Unknown actions are ignored.
+///
+/// Shared by the `polo_zoom:` IPC handler (zoom-bar buttons, Ctrl+wheel) and
+/// the `win.polo-zoom-*` keyboard-shortcut GActions, so the delta math lives
+/// in exactly one place.
+pub fn step(action: &str, webview: &PlatformWebView) {
+    let current = get_preview_zoom();
+    let new_zoom = match action {
+        "in" => current + ZOOM_STEP,
+        "out" => current - ZOOM_STEP,
+        "reset" => ZOOM_DEFAULT,
+        _ => return,
+    };
+    set_preview_zoom(new_zoom, webview);
+}

--- a/polo/src/components/viewer/zoom_bar.rs
+++ b/polo/src/components/viewer/zoom_bar.rs
@@ -1,0 +1,165 @@
+//! In-page zoom toolbar for Polo's preview, plus the Ctrl+wheel zoom handler.
+//!
+//! Same reasoning as Marco's `ZOOM_BAR_HTML` (`marco/src/components/viewer/javascript.rs`):
+//! a native GTK `Overlay` can't draw above an embedded WebView2 child window
+//! on Windows, so the control has to live inside the page itself — and using
+//! the same in-page control on Linux keeps behavior identical across
+//! platforms. Buttons post `polo_zoom:in|out|reset` via IPC; Ctrl+wheel posts
+//! the same messages directly from its own listener.
+//!
+//! Simpler than Marco's bar in two ways:
+//! - No GTK-side hover-tracking hooks: Polo has a single content pane (no
+//!   sibling editor pane competing for pointer focus), so a plain
+//!   `mousemove`-show / timeout-hide works with no native motion-tracking
+//!   plumbing.
+//! - No `polo_zoom:ready` round-trip: Polo re-applies the persisted zoom
+//!   directly from Rust's `connect_load_finished` callback (see
+//!   `viewer::zoom::reapply`), so the page never needs to tell Rust it's
+//!   ready.
+
+/// CSS appended once into every rendered document's `<style>` block. Visually
+/// mirrors Marco's zoom bar (same colors/spacing/hover feel), with
+/// `polo-*`-prefixed ids/classes.
+pub(crate) const CSS: &str = r#"
+#polo-win-zoom{position:fixed;right:10px;bottom:10px;z-index:2147483647;
+    display:flex;align-items:center;gap:0;padding:2px 4px;border-radius:10px;
+    background:rgba(30,30,30,0.72);border:1px solid rgba(255,255,255,0.12);
+    box-shadow:0 2px 8px rgba(0,0,0,0.30);
+    font-family:system-ui,-apple-system,Segoe UI,sans-serif;
+    opacity:0;pointer-events:none;transition:opacity 150ms ease;
+    user-select:none;-webkit-user-select:none;}
+#polo-win-zoom.polo-zoom-visible{opacity:1;pointer-events:auto;}
+#polo-win-zoom.polo-zoom-light{background:rgba(245,245,245,0.88);
+    border-color:rgba(0,0,0,0.14);box-shadow:0 2px 8px rgba(0,0,0,0.14);}
+#polo-win-zoom button{background:transparent;border:0;border-radius:6px;
+    min-width:30px;min-height:30px;padding:2px 6px;
+    color:rgba(220,220,220,0.92);font-size:14px;font-weight:500;
+    cursor:pointer;line-height:1;transition:background 120ms ease;}
+#polo-win-zoom.polo-zoom-light button{color:rgba(40,40,40,0.90);}
+#polo-win-zoom button:hover{background:rgba(255,255,255,0.18);}
+#polo-win-zoom.polo-zoom-light button:hover{background:rgba(0,0,0,0.10);}
+#polo-win-zoom button:active{background:rgba(255,255,255,0.28);}
+#polo-win-zoom.polo-zoom-light button:active{background:rgba(0,0,0,0.18);}
+#polo-win-zoom .polo-zoom-label{color:rgba(200,200,200,0.85);font-size:12px;
+    min-width:36px;padding:0 2px;text-align:center;font-variant-numeric:tabular-nums;}
+#polo-win-zoom.polo-zoom-light .polo-zoom-label{color:rgba(60,60,60,0.85);}
+#polo-win-zoom .polo-zoom-sep{width:1px;align-self:stretch;margin:4px 2px;
+    background:rgba(255,255,255,0.14);}
+#polo-win-zoom.polo-zoom-light .polo-zoom-sep{background:rgba(0,0,0,0.12);}
+"#;
+
+/// Markup + driver script appended once into `<body>` on every rendered
+/// document.
+pub(crate) fn html() -> &'static str {
+    r#"<div id="polo-win-zoom" aria-hidden="true">
+    <button type="button" data-polo-zoom="in" title="Zoom in">+</button>
+    <span class="polo-zoom-sep"></span>
+    <button type="button" data-polo-zoom="out" title="Zoom out">&minus;</button>
+    <span class="polo-zoom-sep"></span>
+    <button type="button" data-polo-zoom="reset" title="Reset zoom">&#x2922;</button>
+    <span class="polo-zoom-sep"></span>
+    <span class="polo-zoom-label" id="polo-win-zoom-label">100%</span>
+</div>
+<script>
+(function(){
+    var bar = document.getElementById('polo-win-zoom');
+    if (!bar) return;
+
+    function applyThemeClass(){
+        var isLight = document.documentElement.className.toLowerCase().indexOf('dark') === -1;
+        bar.classList.toggle('polo-zoom-light', isLight);
+    }
+    applyThemeClass();
+
+    // Relocate onto <html> (a sibling of <body>, not a descendant) so the
+    // bar itself is structurally immune to zoom applied to <body>.
+    function relocate(){
+        if (bar.parentNode !== document.documentElement) {
+            try { document.documentElement.appendChild(bar); } catch(e) {}
+        }
+    }
+    relocate();
+
+    // Reveal on movement anywhere over the page (the whole document *is*
+    // the preview pane here), hide after a short idle period. Polo has no
+    // sibling native pane to lose pointer focus to, so a plain timeout is
+    // enough — no GTK-side motion tracking needed (unlike Marco's bar).
+    var hideTimer = null;
+    function show(){
+        bar.classList.add('polo-zoom-visible');
+        if (hideTimer) clearTimeout(hideTimer);
+        hideTimer = setTimeout(function(){
+            bar.classList.remove('polo-zoom-visible');
+        }, 1500);
+    }
+    document.addEventListener('mousemove', show, {passive:true});
+
+    function send(action){
+        try {
+            if (window.ipc && typeof window.ipc.postMessage === 'function') {
+                window.ipc.postMessage('polo_zoom:' + action);
+            }
+        } catch (e) {}
+    }
+    bar.addEventListener('click', function(e){
+        var btn = e.target && e.target.closest && e.target.closest('button[data-polo-zoom]');
+        if (!btn) return;
+        e.preventDefault();
+        e.stopPropagation();
+        send(btn.getAttribute('data-polo-zoom'));
+    }, true);
+
+    // Ctrl+wheel: one wheel notch = one zoom step, same as the buttons and
+    // the Ctrl+=/Ctrl+-/Ctrl+0 keyboard shortcuts. Plain (non-Ctrl) wheel
+    // scrolling is left completely alone.
+    window.addEventListener('wheel', function(e){
+        if (!e.ctrlKey) return;
+        e.preventDefault();
+        send(e.deltaY < 0 ? 'in' : 'out');
+    }, {passive:false});
+
+    // Apply a zoom level: scale <body> only, never <html>, so the
+    // relocated bar (a sibling of <body>) can't be affected no matter how
+    // the `zoom` property's cascade to descendants behaves.
+    window.__poloApplyZoom = function(z){
+        try {
+            var n = parseFloat(z);
+            if (!isFinite(n) || n <= 0) return;
+            document.body.style.zoom = n;
+            relocate();
+            var lbl = document.getElementById('polo-win-zoom-label');
+            if (lbl) lbl.textContent = Math.round(n * 100) + '%';
+        } catch (e) {}
+    };
+    window.__poloSetZoomLabel = function(pct){
+        var lbl = document.getElementById('polo-win-zoom-label');
+        if (lbl) lbl.textContent = pct + '%';
+    };
+
+    applyThemeClass();
+})();
+</script>"#
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_test_html_contains_bar_and_buttons() {
+        let markup = html();
+        assert!(markup.contains("polo-win-zoom"));
+        assert!(markup.contains("data-polo-zoom=\"in\""));
+        assert!(markup.contains("data-polo-zoom=\"out\""));
+        assert!(markup.contains("data-polo-zoom=\"reset\""));
+        assert!(markup.contains("__poloApplyZoom"));
+        assert!(markup.contains("polo_zoom:"));
+    }
+
+    #[test]
+    fn smoke_test_css_covers_both_themes() {
+        assert!(CSS.contains("#polo-win-zoom"));
+        assert!(CSS.contains("polo-zoom-light"));
+        assert!(CSS.contains("polo-zoom-visible"));
+    }
+}

--- a/polo/src/main.rs
+++ b/polo/src/main.rs
@@ -506,8 +506,25 @@ fn build_ui(app: &Application, file_path: Option<String>, polo_paths: std::rc::R
     // the new page — not when we merely queued it for load.  Without this the
     // bar disappears seconds before the new HTML replaces the old welcome
     // content on screen.
-    webview.connect_load_finished(|| {
-        components::viewer::loading_overlay::hide();
+    webview.connect_load_finished({
+        let webview_for_zoom = webview.clone();
+        move || {
+            components::viewer::loading_overlay::hide();
+            // `style.zoom` lives in the DOM of the page that was just
+            // replaced, so it resets on every navigation — re-apply the
+            // in-session zoom level unconditionally after every load.
+            components::viewer::zoom::reapply(&webview_for_zoom);
+        }
+    });
+
+    // Zoom toolbar buttons and Ctrl+wheel (see `viewer::zoom_bar`) post
+    // `polo_zoom:in|out|reset` over IPC; keyboard shortcuts (`components::menu`)
+    // call `zoom::step` directly — both funnel through the same delta logic.
+    webview.set_zoom_action_handler({
+        let webview_for_zoom = webview.clone();
+        move |action: &str| {
+            components::viewer::zoom::step(action, &webview_for_zoom);
+        }
     });
 
     // Load and render the markdown file


### PR DESCRIPTION
## Summary
- Marco's preview already had a zoom toolbar and Ctrl+=/Ctrl+-/Ctrl+0 shortcuts; Ctrl+scroll wheel now zooms it too, reusing the existing `marco_zoom:` IPC path.
- Polo had no zoom feature at all — it gains the same in-page toolbar, keyboard shortcuts, and Ctrl+wheel. Deliberately session-only (no settings persistence), since Polo opens a different document on every launch.
- Changelog (`changelog/marco.md`, `changelog/polo.md`) and user guide (`documentation/user_guide/user_guide.md`) updated to match.

## Test plan
- [x] `cargo build -p marco -p polo`
- [x] `cargo test -p marco -p polo` (449 + 78 passing)
- [x] Manually verified in both running apps: Ctrl+wheel and Ctrl+=/Ctrl+-/Ctrl+0 zoom the preview, zoom toolbar appears on hover with live percentage